### PR TITLE
Extract additional dimensions from container info

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 py-dateutil
 docker-py>=1.0.0
+jsonpath_rw


### PR DESCRIPTION
Adds the ability to extract arbitrary container information such as
environment variable values, container configuration settings or direct
raw values as extra, additional dimensions reported with the container
metrics (piped through via the `plugin_instance`, using the
`[dim=val,...]` syntax).

See additions to the README.md file for details.

Also included is a fix for the parsing of the container's name in the
presence of Docker links.

In the future, we may want to allow for how those extra dimensions are
passed through to be configurable as well.

Signed-off-by: Maxime Petazzoni max@signalfx.com
