### PR TITLE
Set keyword argument in dateutils.parser to ignore timezones while pa…

### DIFF
--- a/dockerplugin.py
+++ b/dockerplugin.py
@@ -68,7 +68,8 @@ def emit(container, dimensions, point_type, value, t=None,
         val.type_instance = type_instance
 
     if t:
-        val.time = time.mktime(dateutil.parser.parse(t).timetuple())
+        val.time = time.mktime(dateutil.parser.parse(t, ignoretz=True)
+                               .timetuple())
     else:
         val.time = time.time()
 


### PR DESCRIPTION
…rsing

Non-UTC timezones with daylight savings time were producing numeric timestamps that were approximately one hour ahead during daylight savings time.  

The solution was to ignore the timezone during the date stamp parsing.  This will take the UTC offset included in the timestamp provided by the Docker API correctly and not attempt to add or subtract for DST.

This fix has been tested with Hosts set within DST and outside of DST.
