### PR TITLE
Corrected time parsing to make use of calendar.gmtime rather than tim…

### DIFF
--- a/dockerplugin.py
+++ b/dockerplugin.py
@@ -24,6 +24,7 @@
 # Requirements: docker-py
 
 import dateutil.parser
+from calendar import timegm
 from distutils.version import StrictVersion
 import docker
 import json
@@ -68,8 +69,7 @@ def emit(container, dimensions, point_type, value, t=None,
         val.type_instance = type_instance
 
     if t:
-        val.time = time.mktime(dateutil.parser.parse(t, ignoretz=True)
-                               .timetuple())
+        val.time = timegm(dateutil.parser.parse(t).utctimetuple())
     else:
         val.time = time.time()
 


### PR DESCRIPTION
…e.mktime avoiding issues when plugin is running in container that is different timezone from host.

This request corrects an issue observed when running the plugin within a container, where the host is a different timezone from the container.  Ex. Host is set to EDT and Container is set to UTC.

Parsing the timestamps using time.mktime() produces a time in seconds relative to the local time of the container.  Because the values being passed to time.mktime() are just the (y,m,d,hour, min, sec, wd, yd, dst) and then originate from outside of the container in a different timezone, the time is converted into a time relative to the the container which is incorrect.

The solution was to use the Python API feature Calendar.gmtime() which will take a datetime's utctimetuple and produce the correct UTC-GMT time in seconds since the Unix Epoch.  Kudos to @AlmightyOatmeal for this suggestion.  This also removes the need to specify ignoretz which was previously commited.  That addressed a symptom observed on collectd instances running in the same environment as the docker service. 

**Flake8 was run on this code prior to checking in, it passes the 80 character per line limit.
