### PR TITLE
Fixed issue when docker service is halted, container threads sit in e…

### DIFF
--- a/dockerplugin.py
+++ b/dockerplugin.py
@@ -373,8 +373,13 @@ class DockerPlugin:
         return True
 
     def read_callback(self):
-        containers = [c for c in self.client.containers()
-                      if c['Status'].startswith('Up')]
+        try:
+            containers = [c for c in self.client.containers()
+                          if c['Status'].startswith('Up')]
+        except Exception as e:
+            containers = []
+            collectd.info("[dockerplugin]: Failed to retrieve containers from \
+Docker API: %s" % e)
 
         # Terminate stats gathering threads for containers that are not running
         # anymore.


### PR DESCRIPTION
…rror state and are not cleaned up.

Wrapped the call to self.client.containers() in a try/except.  When the client is unreachable, a blank list of containers is passed on and an error statement is logged.  This will ensure that any running threads gathering stats on a container are stopped and removed.  If the client becomes accessible again, the plugin should pick up the new containers and begin gathering stats again.

**Ran Flake8
