### PR TITLE
Turn off log propagation

### DIFF
--- a/dockerplugin.py
+++ b/dockerplugin.py
@@ -552,6 +552,7 @@ class CollectdLogger(logging.Logger):
 logging.setLoggerClass(CollectdLogger)
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
+log.propagate = False
 handle = CollectdLogHandler('docker')
 log.addHandler(handle)
 


### PR DESCRIPTION
Disable log propagation to prevent additional logging to syslog
