### PR TITLE
Fix error when empty string env vars on container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 This file documents important changes to the Docker plugin for collectd. 
 
-- [2016-08-03: Dimensionalize block I/O and CPU per-core metrics](#2016-08-03-dimensionalize-block-i-o-and-cpu-per-core-metrics)
+- [2017-03-29: Improve Dimension Extraction Robustness](#2017-03-29)
+- [2016-08-03: Dimensionalize block I/O and CPU per-core metrics](#2016-08-03)
 
-#### 2016-08-03: Dimensionalize block I/O and CPU per-core metrics
+#### <a name="2017-03-29">2017-03-29: Dimensionalize block I/O and CPU per-core metrics</a>
+
+Improves the stability of the plugin when containers are observed with environment variables set to empty strings.
+
+#### <a name="2016-08-03">2016-08-03: Dimensionalize block I/O and CPU per-core metrics</a>
 
 Prior to this update, the plugin transmitted block I/O and CPU per-core metrics
 with the names of the block device and CPU core respectively included as part of

--- a/dockerplugin.py
+++ b/dockerplugin.py
@@ -272,8 +272,13 @@ class DimensionsProvider:
 
             if provider == 'inspect' or provider == 'env':
                 raw = client.inspect_container(container)
-                env = dict((k, v) for k, v in map(lambda e: e.split('=', 1),
-                                                  raw['Config']['Env']))
+                env = {}
+                for element in map(lambda e: e.split('=', 1),
+                                   raw['Config']['Env']):
+                    if len(element) == 2:
+                        env[element[0]] = element[1]
+                    elif len(element) == 1:
+                        env[element[0]] = ""
 
                 if provider == 'inspect':
                     match = jsonpath_rw.parse(source).find(raw)


### PR DESCRIPTION
Fixes issue where containers were not monitored that had environment variables set to empty string values.
