### PR TITLE
adding open sockets

### DIFF
--- a/dockerplugin.db
+++ b/dockerplugin.db
@@ -8,3 +8,4 @@ network.usage           rx_bytes:COUNTER:0:U, rx_dropped:COUNTER:0:U, rx_errors:
 memory.usage            limit:GAUGE:0:U, max:GAUGE:0:U, total:GAUGE:0:U
 memory.stats            value:GAUGE:0:U
 memory.percent          value:GAUGE:0:150
+open_sockets            value:GAUGE:0:U

--- a/dockerplugin.db
+++ b/dockerplugin.db
@@ -8,4 +8,4 @@ network.usage           rx_bytes:COUNTER:0:U, rx_dropped:COUNTER:0:U, rx_errors:
 memory.usage            limit:GAUGE:0:U, max:GAUGE:0:U, total:GAUGE:0:U
 memory.stats            value:GAUGE:0:U
 memory.percent          value:GAUGE:0:150
-open_sockets            value:GAUGE:0:U
+custom.open_sockets     value:GAUGE:0:U

--- a/dockerplugin.py
+++ b/dockerplugin.py
@@ -120,7 +120,7 @@ def read_open_sockets(container, dimensions, stats, t):
     cpids = psutil.Process(cpid).children(recursive=True)
     s = 0
     for pid in cpids:
-        fd_dir = "{}/{}/fd".format(psutil.PROCFS_PATH, pid.pid)
+        fd_dir = "{}/{}/fd".format('/mnt/proc', pid.pid)
         for fd in os.listdir(fd_dir):
             # fd can be closed between listdir and readlink
             try:

--- a/dockerplugin.py
+++ b/dockerplugin.py
@@ -128,7 +128,7 @@ def read_open_sockets(container, dimensions, stats, t):
                     s += 1
             except OSError as e:
                 continue
-    emit(container, dimensions, 'open_sockets', [s])
+    emit(container, dimensions, 'custom.open_sockets', [s])
 
 def read_blkio_stats(container, dimensions, stats, t):
     """Process block I/O stats for a container."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 py-dateutil
 docker-py>=1.0.0
 jsonpath_rw
+psutil==5.2.2


### PR DESCRIPTION
We're trying to extend this plugin to report on the number of open sockets that a container has open, but running into problems getting it to work.

I've verified that the metric is calculated correctly by setting `Verbose` to `true` and seeing it show up along side the other metrics computed by the plugin, e.g. logs like:
```
[2017-05-05 04:11:45] docker : Value parameters to be emitted:
container : 8b364b4/ecs-agent
dimensions : {}
point_type : custom.open_sockets
value : [0]
type_instance : None 
time : <module 'time' (built-in)>
```

However, I don't see this metric in SignalFX, and if I turn on the CSV plugin to write additionally write all metrics to file, I don't see the custom metric appear there.

I've submitted this PR mostly for guidance, but if you think it's generally useful I'm happy to clean it up for a merge.