### PR TITLE
changes python library from docker-py to docker

### DIFF
--- a/dockerplugin.py
+++ b/dockerplugin.py
@@ -537,7 +537,7 @@ class DockerPlugin:
         self.dimensions = DimensionsProvider(specs)
 
     def init_callback(self):
-        self.client = docker.Client(
+        self.client = docker.APIClient(
             base_url=self.docker_url,
             version=DockerPlugin.MIN_DOCKER_API_VERSION)
         self.client.timeout = self.timeout

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 py-dateutil
-docker-py>=1.0.0
+docker
 jsonpath_rw


### PR DESCRIPTION
New operating systems use docker python module instead of docker-py. It's very similar, just need to change client creation function from docker.Client to docker.APIClient