### PR TITLE
Correct readme and make plugin 2.6 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,11 +218,17 @@ For convenience, you'll find those configuration blocks in the example configura
 If a filter has been configured, then additional resource allocation metrics can be gathered by adding the following snippet to the plugin's filter configuration.
 
 ```apache
-<Rule "Cpu">
+<Rule "CpuShares">
   <Match "regex">
-    Type "^cpu$"
+    Type "^cpu.shares$"
   </Match>
   Target "return"
+</Rule>
+<Rule "CpuQuota">
+<Match "regex">
+  Type "^cpu.quota$"
+</Match>
+Target "return"
 </Rule>
 <Rule "CpuThrottlingData">
   <Match "regex">

--- a/dockerplugin.py
+++ b/dockerplugin.py
@@ -287,7 +287,7 @@ def read_cpu_quota_stats(container, container_inspect, cstats):
                 stats['read'][:-4],
                 "%Y-%m-%dT%H:%M:%S.%f")
         # Time delta in ms between two reads from stats endpoint
-        delta_between_reads = (read - preread).total_seconds() * 1000
+        delta_between_reads = total_milliseconds((read - preread))
         cpu_total = stats['cpu_stats']['cpu_usage']['total_usage']
         precpu_stats = stats['precpu_stats']
         precpu_total = precpu_stats['cpu_usage']['total_usage']
@@ -302,6 +302,13 @@ def read_cpu_quota_stats(container, container_inspect, cstats):
              [quota_used_percent],
              type_instance='used.percent',
              t=stats['read'])
+
+# total_seconds() method of datetime available only from python 2.7
+def total_milliseconds(td):
+    td_microseconds = td.microseconds + \
+                                ((td.seconds + td.days * 24 * 3600) * 10**6)
+    td_milliseconds = td_microseconds / float(10**3)
+    return td_milliseconds
 
 
 class DimensionsProvider:


### PR DESCRIPTION
Updated the readme to correct the filter for new metrics. total_seconds() (of datetime object) is not a method in Python 2.6. Using a new method (Python 2.6 compatible) to handle the scenario.