### PR TITLE
Adding ability to supress network stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ LoadPlugin python
 
 The boolean configuration options CpuQuotaPercent and CpuSharesPercent turn on metrics for CPU quota and CPU shares. Both options are set to False by default.
 
+The boolean option `CollectNetworkStats` controls whether container network
+stats are collected -- it defaults to true.  Some networking backends don't
+report network statistics (e.g. when running on Kubernetes) so it can be useful
+to disable to avoid error messages.
+
 ```apache
 TypesDB "/usr/share/collectd/docker-collectd-plugin/dockerplugin.db"
 LoadPlugin python


### PR DESCRIPTION
They don't work in K8s and cause errors which make the agent look like it has something wrong with it.

Getting rid of all of the logic to only display network errors once.  If network stats error out and network stats are enabled it should show the error every read cycle so the error is clearly shown as ongoing and not just a one time problem.