### PR TITLE
Pinning docker-py dep for Python 2.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 py-dateutil
-docker
+docker<=2.6; python_version == '2.6'
+docker>=2; python_version >= '2.7'
 jsonpath_rw


### PR DESCRIPTION
This is to make Python 2.6 still work.