### PR TITLE
Send additionally rss memory metric (more useful)

### DIFF
--- a/dockerplugin.db
+++ b/dockerplugin.db
@@ -5,7 +5,7 @@ cpu.usage               total:COUNTER:0:U, kernelmode:COUNTER:0:U, usermode:COUN
 cpu.percent             value:GAUGE:0:150
 cpu.throttling_data     periods:COUNTER:0:U, throttled_periods:COUNTER:0:U, throttled_time:COUNTER:0:U
 network.usage           rx_bytes:COUNTER:0:U, rx_dropped:COUNTER:0:U, rx_errors:COUNTER:0:U, rx_packets:COUNTER:0:U, tx_bytes:COUNTER:0:U, tx_dropped:COUNTER:0:U, tx_errors:COUNTER:0:U, tx_packets:COUNTER:0:U
-memory.usage            limit:GAUGE:0:U, max:GAUGE:0:U, total:GAUGE:0:U
+memory.usage            limit:GAUGE:0:U, max:GAUGE:0:U, total:GAUGE:0:U, rss:GAUGE:0:U
 memory.stats            value:GAUGE:0:U
 memory.percent          value:GAUGE:0:150
 cpu.quota               value:GAUGE:0:U

--- a/dockerplugin.py
+++ b/dockerplugin.py
@@ -233,7 +233,7 @@ def read_memory_stats(container, dimensions, stats, t):
     mem_stats = stats['memory_stats']
     log.info('Reading memory stats: {0}'.format(mem_stats))
 
-    values = [mem_stats['limit'], mem_stats['max_usage'], mem_stats['usage']]
+    values = [mem_stats['limit'], mem_stats['max_usage'], mem_stats['usage'], mem_stats['stats']['rss']]
     emit(container, dimensions, 'memory.usage', values, t=t)
 
     detailed = mem_stats.get('stats')


### PR DESCRIPTION
Plugin send this memory  metrics from docker api:
- limit
- max_usage
- usage

Example from docker api:
```
"memory_stats" : {
      "max_usage" : 63183310848,
      "stats" : {
         "rss" : 25776500736,
         "total_pgmajfault" : 145,
         "writeback" : 4096,
         "total_pgfault" : 421774351,
         "pgfault" : 421774351,
         "mapped_file" : 1150976,
         "total_cache" : 29128605696,
         "total_mapped_file" : 1150976,
         "total_pgpgout" : 774821626,
         "hierarchical_memsw_limit" : 128849018880,
         "total_unevictable" : 0,
         "total_active_file" : 9916387328,
         "total_pgpgin" : 788226193,
         "total_inactive_anon" : 270336,
         "rss_huge" : 0,
         "pgpgin" : 788226193,
         "total_swap" : 0,
         "swap" : 0,
         "active_anon" : 25776574464,
         "cache" : 29128605696,
         "total_rss_huge" : 0,
         "total_writeback" : 4096,
         "total_rss" : 25776500736,
         "pgpgout" : 774821626,
         "active_file" : 9916387328,
         "pgmajfault" : 145,
         "inactive_anon" : 270336,
         "total_active_anon" : 25776574464,
         "inactive_file" : 19211866112,
         "unevictable" : 0,
         "total_inactive_file" : 19211866112,
         "hierarchical_memory_limit" : 64424509440
      },
      "usage" : 54905606144,
      "limit" : 64424509440
   },
```
But this metrics not very used in production. Usually, we want to know how much memory consume docker container.  Responsible for this value is `memory_stats['stats']['rss']`. Similar value for memory consume we receive from command `docker stats`.
Therefore, is logical send this new metric.

